### PR TITLE
FY 93 add rollup.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ package-lock.json
 
 # 테스트 파일
 /coverage
+
+# eslint
+
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -1,12 +1,33 @@
 {
-    "name": "rfs",
+    "name": "@42foryou/rfs",
     "description": "React From Scratch",
     "type": "module",
-    "version": "1.0.0",
+    "version": "0.0.1",
+    "main": "dist/rfs.js",
+    "scripts": {
+        "prepare": "git config --local commit.template .gitmessage.txt",
+        "postinstall": "husky install",
+        "format": "prettier --cache --write .",
+        "lint": "eslint --cache .",
+        "test": "jest",
+        "docs": "jsdoc srcs/* -d docs",
+        "build": "rollup -c"
+    },
+    "author": "42foryou",
+    "keywords": [
+        "react"
+    ],
+    "exports": {
+        ".": {
+            "import": "./dist/rfs.js"
+        }
+    },
     "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.11.1",
         "@babel/preset-env": "^7.23.8",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@rollup/plugin-terser": "^0.4.4",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
@@ -16,15 +37,9 @@
         "jira-prepare-commit-msg": "^1.7.2",
         "jsdoc": "^4.0.2",
         "lint-staged": "^15.2.0",
-        "prettier": "^3.2.1"
-    },
-    "scripts": {
-        "prepare": "git config --local commit.template .gitmessage.txt",
-        "postinstall": "husky install",
-        "format": "prettier --cache --write .",
-        "lint": "eslint --cache .",
-        "test": "jest",
-        "docs": "jsdoc srcs/* -d docs"
+        "prettier": "^3.2.1",
+        "rollup": "^4.9.6",
+        "rollup-plugin-size": "^0.3.1"
     },
     "jira-prepare-commit-msg": {
         "messagePattern": "$J/$M",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,9 @@
+import terser from "@rollup/plugin-terser";
+import size from "rollup-plugin-size";
+import resolve from "@rollup/plugin-node-resolve";
+
+export default {
+    input: "./srcs/index.js",
+    output: [{ file: "dist/rfs.js", format: "esm", sourcemap: true }],
+    plugins: [resolve(), terser(), size()],
+};

--- a/srcs/core/createElement.js
+++ b/srcs/core/createElement.js
@@ -1,4 +1,4 @@
-import { isArray as isArr } from "../shared/isArray";
+import isArray from "../shared/isArray";
 
 const RfsElement = (type, props, children) => {
     return {
@@ -16,7 +16,7 @@ const isNoValue = (val) => val === null || val === undefined;
 const flatten = (arr) => {
     return arr.reduce((acc, val) => {
         if (isNoValue(val)) return acc;
-        return isArr(val) ? acc.concat(flatten(val)) : acc.concat(val);
+        return isArray(val) ? acc.concat(flatten(val)) : acc.concat(val);
     }, []);
 };
 

--- a/srcs/index.js
+++ b/srcs/index.js
@@ -1,0 +1,1 @@
+export { createElement, Fragment } from "./core/createElement.js";

--- a/tests/core/createElement.test.html
+++ b/tests/core/createElement.test.html
@@ -24,7 +24,9 @@
             const flatten = (arr) => {
                 return arr.reduce((acc, val) => {
                     if (isNoValue(val)) return acc;
-                    return isArr(val) ? acc.concat(flatten(val)) : acc.concat(val);
+                    return isArr(val)
+                        ? acc.concat(flatten(val))
+                        : acc.concat(val);
                 }, []);
             };
 


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

library bundling을 위해 rollup.js를 추가하였습니다.

npm run build를 통해 build할 수 있으며 dist폴더에 rfs.js라는 이름으로
파일이 생성됩니다.

추후 npm publish를 통해 배포하여 frontend에 포함할 예정입니다.
rollup.js에서 사용한 plugin의 동작은 다음과 같습니다.

resolve: Node.js 스타일의 모듈 해석을 가능하게 합니다 (예: import ... from 'module').
terser: 번들을 최소화(minify)하여 파일 크기를 줄입니다. 이것은 주로 배포를 위한 최적화 단계에서 사용됩니다.
size: 생성된 번들의 크기를 출력합니다. 이는 번들 크기를 모니터링하는 데 유용합니다.

babel과 함께 사용할 수 있습니다.

<!--
 Write Down related JIRA key and url like this
    [key](issue-url)
 -->

[FY-93](https://idealflower.atlassian.net/browse/FY-93)

## PR Checklist

-   [x] I read and included theses actions below

1. I have written documents and tests, if needed.


[FY-93]: https://idealflower.atlassian.net/browse/FY-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ