### PR TITLE
Fy 127 create root

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "jira-prepare-commit-msg": "^1.7.2",
         "jsdoc": "^4.0.2",
         "lint-staged": "^15.2.0",
-        "prettier": "^3.2.1",
+        "prettier": "^3.2.5",
         "rollup": "^4.9.6",
         "rollup-plugin-size": "^0.3.1"
     },

--- a/srcs/core/const.js
+++ b/srcs/core/const.js
@@ -12,3 +12,10 @@ export const DOCUMENT_NODE = 9;
 export const DOCUMENT_TYPE_NODE = 10;
 export const DOCUMENT_FRAGMENT_NODE = 11;
 // HTML node Type ends
+
+// RootTag begins
+// RootTag는 렌더를 할때 어떤 모드로 렌더를 할지를 결정하는 태그입니다.
+// 본 리액트 같은경우는 legacy모드와 concurrent모드가 있습니다.
+// 우리 리액트는 오직 concurrent모드만을 지원합니다.
+export const ConcurrentRoot = 1;
+// RootTag ends

--- a/srcs/core/const.js
+++ b/srcs/core/const.js
@@ -1,0 +1,14 @@
+/**
+ * @file const.js
+ * @description This file defines that HTML nodeType values that represent
+ *  the type of the node
+ * reference: https://developer.mozilla.org/en-US/docs/Web/API/Node
+ */
+
+// HTML node Type begins
+export const ELEMENT_NODE = 1;
+export const TEXT_NODE = 3;
+export const DOCUMENT_NODE = 9;
+export const DOCUMENT_TYPE_NODE = 10;
+export const DOCUMENT_FRAGMENT_NODE = 11;
+// HTML node Type ends

--- a/srcs/core/createRoot.js
+++ b/srcs/core/createRoot.js
@@ -39,9 +39,10 @@ const ReactDOMRoot = class {
 /**
  *
  * @param {container} container -> host Instance를 인자로 받는다-> Element|Document|DocumentFragment
- */
-// createRoot는 해당 Fiber에 대해서 관리를 위한 그 스코프내의 전역관리 공간이라고 생각할 수 있습니다. 그 전역관리 공간의 설정은 해당
+ * @description // createRoot는 해당 Fiber에 대해서 관리를 위한 그 스코프내의 전역관리 공간이라고 생각할 수 있습니다. 그 전역관리 공간의 설정은 해당
 // 짐입점으로 부터 시작하는 createContainer에 의해서 만들어지고, render와 Unmount의 원할한 공유를 위하여 한번 ReactDOMRoot에 의해서 랩핑되어서 반환되어집니다
+ */
+
 export const createRoot = (container) => {
     if (!isValidContainer(container)) {
         throw new Error(

--- a/srcs/core/createRoot.js
+++ b/srcs/core/createRoot.js
@@ -3,8 +3,24 @@
  * @description This file defines the function related to the root of the application.
  */
 
-//todo: implement this function
-const isValidContainer = (container) => {};
+import { ELEMENT_NODE, DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE } from "./const";
+
+/**
+ * @param {container} container-> Type은 노드 타입-> Element|Document|DocumentFragment
+ * @returns {boolean} -> container가 유효한지 확인하는 함수
+ * @description container가 유효한지 확인하는 함수
+ */
+// note: !!()-> implicit type conversion to boolean
+// isValidContainer는 container가 유효한지 확인하는 함수 입니다. 기본적으로 유효한 것은 node여야 되며,
+// 그 node는 ELEMENT_NODE, DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE 중에 하나여야 합니다.
+const isValidContainer = (container) => {
+    return !!(
+        container &&
+        (container.nodeType === ELEMENT_NODE ||
+            container.nodeType === DOCUMENT_NODE ||
+            container.nodeType === DOCUMENT_FRAGMENT_NODE)
+    );
+};
 //todo: implement this function
 const createContainer = (container, RootTag) => {};
 //todo: implement this class

--- a/srcs/core/createRoot.js
+++ b/srcs/core/createRoot.js
@@ -32,9 +32,24 @@ const isValidContainer = (container) => {
 const createContainer = (container, tag) => {
     return createFiberRoot(containerinfo, tag);
 };
-//todo: implement this class
 const ReactDOMRoot = class {
-    constructor(container) {}
+    /**
+     *
+     * @param {inertnalRoot} FiberRootNode
+     * @description ReactDOMRoot는 전역관리 공간인 FiberRootNode를 래핑합니다
+     * @description 이 래핑은 render와 unmount의 원할한 공유를 위하여 이루어집니다
+     */
+    constructor(internalRoot) {
+        this._internalRoot = internalRoot;
+    }
+    /**
+     * @param {children} children -> ReactNodeList, jsx(reactelement) That want to display
+     * @description render는 해당 ReactDOMRoot에 대한 래핑된 FiberRootNode에 대해서 render를 수행합니다
+     * @description 이는 HostRoot의 Update를 Schedule하고, 그에 따른 작업을 수행하는걸 의미합니다
+     */
+    render(children) {
+        updateContainer(children, this._internalRoot, null, null);
+    }
 };
 /**
  *

--- a/srcs/core/createRoot.js
+++ b/srcs/core/createRoot.js
@@ -4,7 +4,8 @@
  */
 
 import { ELEMENT_NODE, DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE } from "./const";
-
+import { ConcurrentRoot } from "./const";
+import { createFiberRoot } from "../fiber/fiberRoot";
 /**
  * @param {container} container-> Type은 노드 타입-> Element|Document|DocumentFragment
  * @returns {boolean} -> container가 유효한지 확인하는 함수
@@ -21,8 +22,16 @@ const isValidContainer = (container) => {
             container.nodeType === DOCUMENT_FRAGMENT_NODE)
     );
 };
-//todo: implement this function
-const createContainer = (container, RootTag) => {};
+
+/**
+ *
+ * @param {container} container -> Element|Document|DocumentFragment
+ * @param {RootTag} RootTag -> Refer to const.js
+ * @returns {fiberRootNode} -> fiberRoot에 대해 globalScope로 역할을 하는 객체를 반환합니다.
+ */
+const createContainer = (container, tag) => {
+    return createFiberRoot(containerinfo, tag);
+};
 //todo: implement this class
 const ReactDOMRoot = class {
     constructor(container) {}
@@ -39,7 +48,6 @@ export const createRoot = (container) => {
             "createRoot: container is not a valid DOM element -RFS error"
         );
     }
-    //TODO: implement this functions
     const root = createContainer(container, ConcurrentRoot);
     //Todo: this will be imported from the event module
     //listenToAllSupportedEvents();

--- a/srcs/core/createRoot.js
+++ b/srcs/core/createRoot.js
@@ -1,0 +1,37 @@
+/**
+ * @file createRoot.js
+ * @description This file defines the function related to the root of the application.
+ */
+
+//todo: implement this function
+const isValidContainer = (container) => {};
+//todo: implement this function
+const createContainer = (container, RootTag) => {};
+//todo: implement this class
+const ReactDOMRoot = class {
+    constructor(container) {}
+};
+/**
+ *
+ * @param {container} container -> host Instance를 인자로 받는다-> Element|Document|DocumentFragment
+ */
+// createRoot는 해당 Fiber에 대해서 관리를 위한 그 스코프내의 전역관리 공간이라고 생각할 수 있습니다. 그 전역관리 공간의 설정은 해당
+// 짐입점으로 부터 시작하는 createContainer에 의해서 만들어지고, render와 Unmount의 원할한 공유를 위하여 한번 ReactDOMRoot에 의해서 랩핑되어서 반환되어집니다
+export const createRoot = (container) => {
+    if (!isValidContainer(container)) {
+        throw new Error(
+            "createRoot: container is not a valid DOM element -RFS error"
+        );
+    }
+    //TODO: implement this functions
+    const root = createContainer(container, ConcurrentRoot);
+    //Todo: this will be imported from the event module
+    //listenToAllSupportedEvents();
+    //
+    return new ReactDOMRoot(root);
+};
+
+/**
+ * @param {container} container
+ * @param {rootTag} RootTag // refer to const.js
+ */

--- a/srcs/core/type.js
+++ b/srcs/core/type.js
@@ -1,0 +1,14 @@
+/**
+ * @typedef {Object} TRfsElement
+ * @property {null | string | number?} key
+ * @property {string | function} type
+ * @property {any} props
+ * @property {any} ref
+ */
+const TRfsElement = {
+    type: null | String | Function,
+    // props can cantain children array. and properties.
+    props: null | any,
+    key: null | String | Number,
+    ref: null | any,
+};

--- a/srcs/fiber/fiber.js
+++ b/srcs/fiber/fiber.js
@@ -1,0 +1,64 @@
+import { HostRoot } from "./type";
+/**
+ * 
+ * @param {tag} TWorkTag 
+ * @param {pendingProps} pendingProps -> props of the fiber will be rendered
+ * @param {key} key = null | string -> conceptual identifier
+ * @property {*} ->TFiber
+ * @returns {TFiber}
+ @description constructor for FiberNode
+*/
+const FiberNode = class {
+    constructor(tag, pendingProps, key) {
+        this.tag = tag;
+        this.key = key;
+        this.elementType = null;
+        this.type = null;
+        this.stateNode = null;
+
+        //related with Tree
+        this.return = null;
+        this.child = null;
+        this.sibling = null;
+        this.index = 0;
+
+        this.ref = null;
+
+        //related with Props
+        this.pendingProps = pendingProps;
+        this.memoizedProps = null;
+
+        this.updateQueue = null;
+
+        this.alternate = null;
+
+        //related with Effect
+        //flags will be noflags
+        this.flags = null;
+        this.subtreeFlags = null;
+        this.deletions = null;
+    }
+};
+
+/**
+ *
+ * @param {tag} TWorkTag
+ * @param {pendingProps} pendingProps -> props of the fiber will be rendered
+ * @param {key} key = null | string -> conceptual identifier
+ * @returns {TFiber}
+ * @description createFiber function will create a new FiberNode
+ * @description this is because that seperate Constructor's implementation from the create function
+ */
+const createFiber = (tag, pendingProps, key) => {
+    return new FiberNode(tag, pendingProps, key);
+};
+
+/**
+ *
+ * @param {tag} RootTag -> core/const.js
+ * @returns TFiber
+ * @description createHostRootFiber function will create a new FiberNode with HostRoot tag
+ */
+export const createHostRootFiber = (tag) => {
+    return createFiber(HostRoot, null, null);
+};

--- a/srcs/fiber/fiberRoot.js
+++ b/srcs/fiber/fiberRoot.js
@@ -51,7 +51,6 @@ export const createFiberRoot = (containerInfo, tag) => {
  * @description    fiberRoot에 대응되는 HostRootFiber를 생성시키고
     // FiberRoot에 연결하며
     // 그 Fiber에 대해서 Root의 Container를 연결시켜줍니다.
-    @description Note!! side effect를 가지고 있음으로 단순히 추상적 의미로만 사용하시길 바랍니다. 재사용불가능합니다
     @return {Fiber} -> hostRootFiber를 반환합니다.
     */
     const bindFiberRootToHostRootFiber = (tag, FiberRoot) => {

--- a/srcs/fiber/fiberRoot.js
+++ b/srcs/fiber/fiberRoot.js
@@ -35,21 +35,6 @@ const FiberRootNode = class {
 };
 
 /**
- * @param {tag} RootTag -> Refer to const.js
- * @param {FiberRoot} FiberRoot -> FiberRoot
- * @description    fiberRoot에 대응되는 HostRootFiber를 생성시키고
-    // FiberRoot에 연결하며
-    // 그 Fiber에 대해서 Root의 Container를 연결시켜줍니다.
-    @description Note!! side effect를 가지고 있음으로 단순히 추상적 의미로만 사용하시길 바랍니다. 재사용불가능합니다
-    @return {Fiber} -> hostRootFiber를 반환합니다.
-    */
-const bindFiberRootToHostRootFiber = (tag, FiberRoot) => {
-    const FiberBoundedRoot = createHostRootFiber(tag);
-    FiberRoot.current = FiberBoundedRoot;
-    FiberBoundedRoot.stateNode = FiberRoot;
-    return FiberBoundedRoot;
-};
-/**
  * @param {containerinfo} container -> host Instance를 인자로 받는다-> Element|Document|DocumentFragment
  * @param {tag} RootTag -> Refer to const.js
  * @description FiberRoot는 해당 Fiber에 대해서 관리를 위한 그 스코프내의 전역관리 공간이라고 생각할 수 있습니다. 그 전역관리 공간의 설정은 해당 Class
@@ -60,6 +45,21 @@ const bindFiberRootToHostRootFiber = (tag, FiberRoot) => {
 export const createFiberRoot = (containerInfo, tag) => {
     const root = new FiberRootNode(containerInfo, tag);
 
+    /**
+ * @param {tag} RootTag -> Refer to const.js
+ * @param {FiberRoot} FiberRoot -> FiberRoot
+ * @description    fiberRoot에 대응되는 HostRootFiber를 생성시키고
+    // FiberRoot에 연결하며
+    // 그 Fiber에 대해서 Root의 Container를 연결시켜줍니다.
+    @description Note!! side effect를 가지고 있음으로 단순히 추상적 의미로만 사용하시길 바랍니다. 재사용불가능합니다
+    @return {Fiber} -> hostRootFiber를 반환합니다.
+    */
+    const bindFiberRootToHostRootFiber = (tag, FiberRoot) => {
+        const FiberBoundedRoot = createHostRootFiber(tag);
+        FiberRoot.current = FiberBoundedRoot;
+        FiberBoundedRoot.stateNode = FiberRoot;
+        return FiberBoundedRoot;
+    };
     const FiberBoundedRoot = bindFiberRootToHostRootFiber(tag, root);
     //todo :: code for initializing the memoizedState
 

--- a/srcs/fiber/fiberRoot.js
+++ b/srcs/fiber/fiberRoot.js
@@ -1,0 +1,67 @@
+import { createHostRootFiber } from "./fiber.js";
+
+/**
+    @description FiberRoot는 해당 Fiber에 대해서 관리를 위한 그 스코프내의 전역관리 공간이라고 생각할 수 있습니다. 
+    그 전역관리 공간의 설정은 해당 Class에 의해 관리됩니다
+ */
+const FiberRootNode = class {
+    /**
+     * @param {containerinfo} container -> host Instance를 인자로 받는다-> Element|Document|DocumentFragment
+     * @param {tag} RootTag -> Refer to const.js
+     * @description 생성자
+     * @property {tag} tag -> RootTag를 저장합니다.
+     * @property {containerinfo} container를 저장 -> Element|Document|DocumentFragment
+     * @property {pendingChildren} pendingChildren -> 아직 처리되지 않은 컴포넌트 임시저장소
+     * @property {current} current -> 현재 활성화된 Fiber Tree에대한 참조
+     * @property {finishedWork} finishedWork -> 렌더가 완료된 Fiber Nodes
+     * @property {cancelPendingCommit} cancelPendingCommit -> 비동기적 요청의 순서를 보장하기 위한 정보
+     * @property {context} context -> 현재 context value
+     * @property {pendingContext} pendingContext -> 바뀔거지만 아직 확정되진 않은 context value-> 나중에 context랑 교환
+     * @property {next} next -> scheduling에서 다음 작업에 대한 참조
+     * @property {callbackNode} callbackNode -> 비동기 작업을 위한 callbackFunction의 참조
+     */
+    constructor(containerInfo, tag) {
+        this.tag = tag;
+        this.containerInfo = containerInfo;
+        this.pendingChildren = null;
+        this.current = null;
+        this.finishedWork = null;
+        this.cancelPendingCommit = null;
+        this.context = null;
+        this.pendingContext = null;
+        this.next = null;
+        this.callbackNode = null;
+    }
+};
+/**
+ * @param {containerinfo} container -> host Instance를 인자로 받는다-> Element|Document|DocumentFragment
+ * @param {tag} RootTag -> Refer to const.js
+ * @description FiberRoot는 해당 Fiber에 대해서 관리를 위한 그 스코프내의 전역관리 공간이라고 생각할 수 있습니다. 그 전역관리 공간의 설정은 해당 Class
+ * 에 의해서 생성되며 그렇게 생성된 객체에 실제 대응될 Fiber를 생성하여 연결을 시켜줍니다. 그리고 conatiner를 생성된 파이버와 연결시켜줍니다.
+ * 이후에 memoizedState를 초기화 시켜주고, updateQueue를 초기화 시켜줍니다.-> Todo: implement this functions
+ * @returns {fiberRootNode} -> fiberRoot에 대해 globalScope로 역할을 하는 객체를 반환합니다.
+ */
+/**
+ * @param {tag} RootTag -> Refer to const.js
+ * @param {FiberRoot} FiberRoot -> FiberRoot
+ * @description    fiberRoot에 대응되는 HostRootFiber를 생성시키고
+    // FiberRoot에 연결하며
+    // 그 Fiber에 대해서 Root의 Container를 연결시켜줍니다.
+    @description Note!! side effect를 가지고 있음으로 단순히 추상적 의미로만 사용하시길 바랍니다. 재사용불가능합니다
+    @return {Fiber} -> hostRootFiber를 반환합니다.
+    */
+const bindFiberRootToHostRootFiber = (tag, FiberRoot) => {
+    const FiberBoundedRoot = createHostRootFiber(tag);
+    FiberRoot.current = FiberBoundedRoot;
+    FiberBoundedRoot.stateNode = FiberRoot;
+    return FiberBoundedRoot;
+};
+export const createFiberRoot = (containerInfo, tag) => {
+    const root = new FiberRootNode(containerInfo, tag);
+
+    const FiberBoundedRoot = bindFiberRootToHostRootFiber(tag, root);
+    //todo :: code for initializing the memoizedState
+
+    //todo:: initilizing updateQueue into FiberBoundedRoot
+    return root;
+};

--- a/srcs/fiber/fiberRoot.js
+++ b/srcs/fiber/fiberRoot.js
@@ -33,14 +33,7 @@ const FiberRootNode = class {
         this.callbackNode = null;
     }
 };
-/**
- * @param {containerinfo} container -> host Instance를 인자로 받는다-> Element|Document|DocumentFragment
- * @param {tag} RootTag -> Refer to const.js
- * @description FiberRoot는 해당 Fiber에 대해서 관리를 위한 그 스코프내의 전역관리 공간이라고 생각할 수 있습니다. 그 전역관리 공간의 설정은 해당 Class
- * 에 의해서 생성되며 그렇게 생성된 객체에 실제 대응될 Fiber를 생성하여 연결을 시켜줍니다. 그리고 conatiner를 생성된 파이버와 연결시켜줍니다.
- * 이후에 memoizedState를 초기화 시켜주고, updateQueue를 초기화 시켜줍니다.-> Todo: implement this functions
- * @returns {fiberRootNode} -> fiberRoot에 대해 globalScope로 역할을 하는 객체를 반환합니다.
- */
+
 /**
  * @param {tag} RootTag -> Refer to const.js
  * @param {FiberRoot} FiberRoot -> FiberRoot
@@ -56,6 +49,14 @@ const bindFiberRootToHostRootFiber = (tag, FiberRoot) => {
     FiberBoundedRoot.stateNode = FiberRoot;
     return FiberBoundedRoot;
 };
+/**
+ * @param {containerinfo} container -> host Instance를 인자로 받는다-> Element|Document|DocumentFragment
+ * @param {tag} RootTag -> Refer to const.js
+ * @description FiberRoot는 해당 Fiber에 대해서 관리를 위한 그 스코프내의 전역관리 공간이라고 생각할 수 있습니다. 그 전역관리 공간의 설정은 해당 Class
+ * 에 의해서 생성되며 그렇게 생성된 객체에 실제 대응될 Fiber를 생성하여 연결을 시켜줍니다. 그리고 conatiner를 생성된 파이버와 연결시켜줍니다.
+ * 이후에 memoizedState를 초기화 시켜주고, updateQueue를 초기화 시켜줍니다.-> Todo: implement this functions
+ * @returns {fiberRootNode} -> fiberRoot에 대해 globalScope로 역할을 하는 객체를 반환합니다.
+ */
 export const createFiberRoot = (containerInfo, tag) => {
     const root = new FiberRootNode(containerInfo, tag);
 

--- a/srcs/fiber/type.js
+++ b/srcs/fiber/type.js
@@ -1,0 +1,71 @@
+// TWorkTag Type begins
+/**
+ *@typedef TWorkTag
+ */
+const TWorkTag = {}; // only for editor to recognize the type
+export const FunctionComponent = 0; //to represent the function component
+export const HostRoot = 1; // to represent the HostTree Root Node
+export const HostComponent = 2; // to represent the Host Component
+export const HostText = 3; // to represent the Host Text
+export const Fragment = 4; // to represent the Fragment
+export const ContextProvider = 5; // to represent the Context Provider
+export const MemoComponent = 6; // to represent the HighOrderComponent created by memo
+
+const TRefObject = {
+    current: any,
+};
+
+const TEFlags = {}; // Todo: implement this type
+// TWorkTag Type ends
+/**
+ * @typedef {Object} Tfiber
+ * @property {TWorkTag} tag
+ * @property {null | string | number?} key
+ * @property {string | function} type
+ * @property {any} stateNode
+ * @property {TFiber | null} return
+ * @property {TFiber | null} child
+ * @property {TFiber | null} sibling
+ * @property {number} index
+ * @property {any} props
+ * @property {any} ref
+ * @property {THookObject | null} memoizedState
+ * @property {TDependencies | null} dependencies
+ * @property {TFiber | null} nextEffect
+ * @property {TFiber | null} firstEffect
+ * @property {TFiber | null} lastEffect
+ * @property {TFiber | null} alternate
+ */
+const TFiber = {
+    tag: TWorkTag,
+    key: null | String, // conceptual identifier
+    elementType: String | Function, // to represent Defined Type of Component, to Preserve Original Type for High Order Component
+    type: String | Function, // to represent Instance Type of Component
+    stateNode: any, // to represent host instance.
+
+    //related with Tree
+    return: TFiber | null, // to represent the parent of the fiber
+    child: TFiber | null, // to represent the first child of the fiber
+    sibling: TFiber | null, // to represent the next sibling of the fiber
+    index: Number, // to represent the index of the child in the parent's children array
+
+    ref: TRefObject | null, // to represent the ref of the fiber
+
+    //related with Props
+    pendingProps: any, // to represent the props of the fiber
+    memoizedProps: any, // to represent the memoized props of the fiber
+
+    updateQueue: any, // to saving effect information
+
+    alternate: TFiber | null, // to represent the old version of the fiber
+
+    //related with Effect
+    flags: TEFlags, // to represent the flags of the fiber
+    subtreeFlags: TEFlags, // to represent the subtree flags of the fiber
+    deletions: [], // to represent the deletions of the fiber, to tracks for child node to be deleted
+
+    //Effect with prefix ->to Deliver effect(sideeffect) to parent
+    firstEffect: TFiber | null, // TOdo: to determine this type
+    lastEffect: TFiber | null, // Todo: to determine this type
+    nextEffect: TFiber | null, // Todo: to determine this type
+};

--- a/srcs/fiber/type.js
+++ b/srcs/fiber/type.js
@@ -60,8 +60,8 @@ const TFiber = {
     alternate: TFiber | null, // to represent the old version of the fiber
 
     //related with Effect
-    flags: TEFlags, // to represent the flags of the fiber
-    subtreeFlags: TEFlags, // to represent the subtree flags of the fiber
+    flags: TEFlags | null, // to represent the flags of the fiber
+    subtreeFlags: TEFlags | null, // to represent the subtree flags of the fiber
     deletions: [], // to represent the deletions of the fiber, to tracks for child node to be deleted
 
     //Effect with prefix ->to Deliver effect(sideeffect) to parent

--- a/types.js
+++ b/types.js
@@ -3,14 +3,6 @@
  * @description This file defines the types of the core object.
  */
 
-// workTag
-// const HostRoot /**                 */ = 0
-// const FunctionComponent /**        */ = 1
-// const HostComponent /**            */ = 2
-// const HostText /**                 */ = 3
-// const Fragment /**                 */ = 4
-// const MemoComponent /**            */ = 5
-
 // effectTag
 // const ONCE = Symbol.for("ONCE");
 // const EXEC_EFFECT = Symbol.for("USEEFFECT");
@@ -41,83 +33,3 @@ const THookObject = Object.freeze({
     queue: null,
     next: null,
 });
-
-/**
- * @typedef {Object} TRfsElement
- * @property {null | string | number?} key
- * @property {string | function} type
- * @property {any} props
- * @property {any} ref
- */
-const TRfsElement = {
-    type: null | String | Function,
-    // props can cantain children array. and properties.
-    props: null | any,
-    key: null | String | Number,
-    ref: null | any,
-};
-
-/**
- * @typedef {Object} Tfiber
- * @property {TWorkTag} tag
- * @property {null | string | number?} key
- * @property {string | function} type
- * @property {any} stateNode
- * @property {TFiber | null} return
- * @property {TFiber | null} child
- * @property {TFiber | null} sibling
- * @property {number} index
- * @property {any} props
- * @property {any} ref
- * @property {THookObject | null} memoizedState
- * @property {TDependencies | null} dependencies
- * @property {TFiber | null} nextEffect
- * @property {TFiber | null} firstEffect
- * @property {TFiber | null} lastEffect
- * @property {TFiber | null} alternate
- */
-const TFiber = {
-    // Tag identifying the type of fiber.
-    tag: TWorkTag,
-    // Unique identifier of this child. ex) <li>
-    key: null | String | Number,
-    // This property can seperate between HTML elements and Component
-    type: null | String | Function,
-    // The local state associated with this fiber.
-    stateNode: any | null,
-
-    // The Fiber to return to after finishing processing this one.
-    // This is effectively the parent, but there can be multiple parents (two)
-    // so this is only the parent of the thing we're currently processing.
-    // It is conceptually the same as the return address of a stack frame.
-    return: TFiber | null,
-    // Singly Linked List Tree Structure.
-    child: TFiber | null,
-    sibling: TFiber | null,
-    index: Number,
-
-    // Input is the data coming into process this fiber. Arguments. Props.
-    props: any | null,
-    // The ref last used to attach this node.
-    ref: any | null,
-
-    // The hook state used to create the output
-    memoizedState: THookObject | null,
-
-    // Dependencies (contexts, events) for this fiber, if it has any
-    dependencies: TDependencies | null,
-
-    // Singly linked list fast path to the next fiber with side-effects.
-    nextEffect: TFiber | null,
-
-    // The first and last fiber with side-effect within this subtree. This allows
-    // us to reuse a slice of the linked list when we reuse the work done within
-    // this fiber.
-    firstEffect: TFiber | null,
-    lastEffect: TFiber | null,
-
-    // This is a pooled version of a Fiber. Every fiber that gets updated will
-    // eventually have a pair. There are cases when we can clean up pairs to save
-    // memory if we need to.
-    alternate: TFiber | null,
-};


### PR DESCRIPTION
## Overview

createRoot와 관련된 사항과 Fiber명세의 수정 및 Fiber생성관련 함수들을 작성하였습니다.
createRoot는 FiberRoot라는 reactRender를 위한 렌더 트리 글로벌 스코프정보공간을 만들어주는것을 의미합니다.
현재 테스트 코드는 없는데 그 이유는 초기 세팅해서 넣어두는 관련된 코드이고 , 후에 통합테스트로 진행할 예정입니다.


## PR Checklist

-   [ ] I read and included theses actions below

1. I have written documents and tests, if needed.
