### PR TITLE
FY-187/feat(hook): add useRef

### DIFF
--- a/srcs/hooks/core/hooksDispatcher.js
+++ b/srcs/hooks/core/hooksDispatcher.js
@@ -5,6 +5,7 @@
 
 import { mountReducer, updateReducer } from "../useReducer/useReducerImpl";
 import { mountEffect, updateEffect } from "../useEffect/useEffectImpl";
+import { mountRef, updateRef } from "../useRef/useRefImpl";
 
 /**
  * @description This object is dispatcher for mount hooks.
@@ -18,6 +19,7 @@ export const hookDispatcherOnMount = {
     useReducer: mountReducer,
     useEffect: mountEffect,
     // useMemo: mountMemo,
+    useRef: mountRef,
 };
 
 /**
@@ -32,4 +34,5 @@ export const hookDispatcherOnUpdate = {
     useReducer: updateReducer,
     useEffect: updateEffect,
     // useMemo: updateMemo,
+    useRef: updateRef,
 };

--- a/srcs/hooks/index.js
+++ b/srcs/hooks/index.js
@@ -1,4 +1,5 @@
 import useReducer from "./useReducer/useReducer.js";
 import useEffect from "./useEffect/useEffect.js";
+import useRef from "./useRef/useRef.js";
 
-export { useReducer, useEffect };
+export { useReducer, useEffect, useRef };

--- a/srcs/hooks/useRef/useRef.js
+++ b/srcs/hooks/useRef/useRef.js
@@ -3,18 +3,15 @@
  * @description This module defines the useRef function.
  */
 
-import c from "../core/core";
+import hookCore from "../core/core";
 
 /**
  * @description This function is useRef hook.
  * @argument {any} initialValue
  * @returns {Object} {current: initialValue}
  */
-export const useRef = (initialValue) => {
-    return c.RfsCurrentDispatcher.current.useMemo(
-        () => ({
-            current: initialValue,
-        }),
-        []
-    );
+const useRef = (initialValue) => {
+    return hookCore.RfsCurrentDispatcher.current.useRef(initialValue);
 };
+
+export default useRef;

--- a/srcs/hooks/useRef/useRefImpl.js
+++ b/srcs/hooks/useRef/useRefImpl.js
@@ -1,0 +1,31 @@
+/**
+ * @module useRefImpl
+ * @description This module defines the useRef function.
+ * useRef훅은 단순히 hook.memoizedState에 ref Object를 저장하는 것에 불과합니다.
+ * fiber가 hostInstance에 ref property를 연결함으로써 fiber의 stateNode를 ref로 사용할 수 있게 됩니다.
+ * 즉 browser라면 Dom Note에 연결 할 수 있습니다.
+ * 혹은 render를 일으키지 않고 컴포넌트의 라이프사이클동안 변경될 수 있는 값을 사용할 때도 유용합니다.
+ */
+
+/**
+ *
+ * @param {any} initialValue
+ * @description This function is useRef hook.
+ * @returns {Object} {current: initialValue}
+ */
+export const mountRef = (initialValue) => {
+    const hook = mountWorkInProgressHook();
+    const ref = { current: initialValue };
+    hook.memoizedState = ref;
+    return ref;
+};
+
+/**
+ *
+ * @param {Any} initialValue
+ * @returns {Object} {current: initialValue}
+ */
+export const updateRef = (_) => {
+    const hook = updateWorkInProgressHook();
+    return hook.memoizedState;
+};

--- a/srcs/index.js
+++ b/srcs/index.js
@@ -1,3 +1,3 @@
 export { createElement, Fragment } from "./core/createElement.js";
 
-export { useReducer, useEffect } from "./hooks/index.js";
+export { useReducer, useEffect, useRef } from "./hooks/index.js";


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

useRef는 간단한 hook입니다. 컴포넌트의 렌더링을 일으키지 않고 해당 컴포넌트의 라이프 사이클 동안 값을 유지할 수 있습니다.
이러한 특성 덕분에 function component에서 렌더링을 일으키지 않고 fiber의 ref에 값을 attach, detach하며 hostInstance에 요소들을 직접 조작할 수 있습니다.

useRef의 사용법은 크게 두가지로 나뉘어집니다. 

1. 해당 컴포넌트의 라이프 사이클 동안 값을 유지. (일반 지역변수는 component render시에 다시 할당됨)
2. HostInstance에 ref를 주게 되면 해당 fiber의  stateNode를 참조하여 hostinstace의 reference를 얻을 수 있음. 

useRef의 동작은 굉장히 간단하기 때문에 Notion에는 이것을 사용하는 commitRoot부분을 조금 더 자세히 명세하였습니다. 

<!--
 Write Down related JIRA key and url like this
    [key](issue-url)
 -->

[FY-187](https://idealflower.atlassian.net/browse/FY-187)

## PR Checklist

-   [ ] I read and included theses actions below

1. I have written documents and tests, if needed.


[FY-187]: https://idealflower.atlassian.net/browse/FY-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ