### PR TITLE
FY-202/feat(work): 비동기 렌더 로직구현(performConcurrentWork)

### DIFF
--- a/srcs/fiber/fiberRoot.js
+++ b/srcs/fiber/fiberRoot.js
@@ -77,3 +77,18 @@ export const markRootUpdatedAtTime = (root, expirationTime) => {
         root.firstPendingTime = expirationTime;
     }
 };
+
+/**
+ *
+ * @param {TFiberRoot} root @see 파일경로: srcs/type/TFiberRoot.js
+ * @param {TExpirationTime} expirationTime @see 파일경로: srcs/type/TExpirationTime.js
+ * @description 현재 루트의 만료시간을 설정합니다. 이는 보통 타임아웃과 관련이 있습니다.
+ */
+export const markRootExpiredAtTime = (root, expirationTime) => {
+    const lastExpiredTime = root.lastExpiredTime;
+    //여기선 만료시간의 문맥이라 expirationTime보다 lastExpiredTime이 작다면 더 최근에 일어난 것
+    //이라는 뜻이다. 그러므로 lastExpiredTime을 expirationTime으로 설정해준다.
+    if (lastExpiredTime === NoWork || lastExpiredTime > expirationTime) {
+        root.lastExpiredTime = expirationTime;
+    }
+};


### PR DESCRIPTION
비동기관련 렌더 로직의 구현을 완성했습니다. 코드 내에서 사용하는 스케쥴 api를 다음 작업으로 진행할 예정입니다. 해당 구현사항에서 performConcurrentWorkOnRoot에서 의 반환값이 어떤식으로 사용되는지 확인해야합니다.

## Overview

비동기 관련된 렌더 로직을 완성했습니다. 다음 구현은 스케쥴 관련 구현이 될것같습니다.
자세한 로직은 커밋내용과 주석을 참고하시길 바랍니다.

[FY-](https://idealflower.atlassian.net/ blahblah)

## PR Checklist

-   [ ] I read and included theses actions below

1. I have written documents and tests, if needed.
